### PR TITLE
age & "mud pieno" al login - fix

### DIFF
--- a/src/comm.c
+++ b/src/comm.c
@@ -33,7 +33,7 @@
 #include "config.h"
 #define PIDFILE "myst.pid"
 #define MAXIDLESTARTTIME 1000
-#define MAX_CONNECTS 256  /* max number of descriptors (connections) */
+#define MAX_CONNECTS 1024  /* max number of descriptors (connections) */
                           /* THIS IS SYSTEM DEPENDANT, use 64 is not sure! */
 
 

--- a/src/db.c
+++ b/src/db.c
@@ -3604,14 +3604,20 @@ void reset_char(struct char_data *ch) {
   //{
   //GET_LEVEL(ch,0) = 60;
   //}
-  if (!strcmp(GET_NAME(ch), "UlTiMaRiSoRsA")) {
+  if (!strcmp(GET_NAME(ch), "Alar")) { //Giovanni
     GET_LEVEL(ch, 0) = 60;
   }
-  if (!strcmp(GET_NAME(ch), "Jethro")) {
-    GET_LEVEL(ch, 0) = 60;
-  }
-  if (!strcmp(GET_NAME(ch), "Isildur")) {
+  if (!strcmp(GET_NAME(ch), "Isildur")) { //Nicola
     GET_LEVEL(ch, 0) = 59;
+  }
+  if (!strcmp(GET_NAME(ch), "Requiem")) { //Francesco
+    GET_LEVEL(ch, 0) = 59;
+  }
+  if (!strcmp(GET_NAME(ch), "Flyp")) { //Enrico
+    GET_LEVEL(ch, 0) = 59;
+  }
+  if (!strcmp(GET_NAME(ch), "Storm")) { //Marcowrebuild
+    GET_LEVEL(ch, 0) = 58;
   }
 
   /* this is to clear up bogus levels on people that where here before */

--- a/src/db.c
+++ b/src/db.c
@@ -210,10 +210,10 @@ void boot_db() {
   else
     wizhelp_index = build_help_index(wizhelp_fl, &top_of_wizhelpt);
 
-#if CLEAN_AT_BOOT
+/*#if CLEAN_AT_BOOT
   mudlog(LOG_CHECK, "Clearing inactive players");
   clean_playerfile();
-#endif
+#endif*/
 
   mudlog(LOG_CHECK, "Booting mail system.");
   if (!scan_mail_file()) {
@@ -4559,7 +4559,7 @@ void ConvertPlayerFile(void) {
 
 
 
-void clean_playerfile() {
+/*void clean_playerfile() {
 
   struct junk {
     struct char_file_u dummy;
@@ -4580,9 +4580,9 @@ void clean_playerfile() {
   timeH = time(0);
 
   mudlog(LOG_SYSERR, "time now %i", timeH);
-  /* Probabilmente questa si puo eliminare 
+  * Probabilmente questa si puo eliminare
    
-     ConvertPlayerFile();*/
+     ConvertPlayerFile();*
 
   if ((dir = opendir(PLAYERS_DIR)) != NULL) {
     while ((ent = readdir(dir)) != NULL) {
@@ -4610,14 +4610,14 @@ void clean_playerfile() {
              mudlog(LOG_SYSERR,"Nome: %s",grunt.dummy.name);
             num_processed++;
 
-            /* Fa la lista dei personaggi attivi.. a bit tedious */
+            * Fa la lista dei personaggi attivi.. a bit tedious *
             char *classname[] = {"Mu", "Cl", "Wa", "Th", "Dr", "Mo", "Ba", "So", "Pa","Ra", "Ps", "?", "??"};
             char classes[100];
             classes[0] = '\0';
             int i;
 
             for (i = max = 0; i < MAX_CLASS; i++) {
-              /*calcola il livello piu` alto in max*/
+              *calcola il livello piu` alto in max*
               if (grunt.dummy.level[ i ] > max)
                 max = grunt.dummy.level[ i ];
 
@@ -4634,7 +4634,7 @@ void clean_playerfile() {
                       grunt.dummy.name,
                       classes, grunt.dummy.points.max_hit);
             }
-
+              
             if (max < IMMORTALE) {
               j = (int) max;
               if (j < 5)
@@ -4642,8 +4642,8 @@ void clean_playerfile() {
 
               age = timeH - grunt.dummy.last_logon;
 
-              mudlog(LOG_SYSERR, "*****%s****Last logon: %i***age-->%i", grunt.dummy.name, grunt.dummy.last_logon, age);
-              mudlog(LOG_SYSERR, "*****%s", grunt.dummy.description);
+              mudlog(LOG_SYSERR, "*****%s****Last logon: %i***tempo intercorso-->%i", grunt.dummy.name, grunt.dummy.last_logon, age);
+              mudlog(LOG_SYSERR, "*****%s", grunt.dummy.description); */
               
               
               /* BUG BUG BUG */
@@ -4667,7 +4667,7 @@ void clean_playerfile() {
                 }
               } */
                 
-              /* Avviso di cancellazione imminente*/
+              /* Avviso di cancellazione imminente *
 
               if (!grunt.AXE && age > (long) (j - 1) * (SECS_PER_REAL_DAY * 7) && !IS_SET(grunt.dummy.user_flags, NO_DELETE)) {
                 num_warned++;
@@ -4689,7 +4689,7 @@ void clean_playerfile() {
             fclose(pFile);
 
             if (grunt.AXE) {
-#ifndef NOREGISTER	 
+#ifndef NOREGISTER	 */
 
               /*******
               Flyp: cancellazione da riverificare
@@ -4709,6 +4709,7 @@ void clean_playerfile() {
               system( buf );
               mudlog(LOG_CHECK,"%s cancellato per inattivita'",grunt.dummy.name);
                *************/
+/*
 #else
               mudlog(LOG_CHECK, "%s doveva essere cancellato", grunt.dummy.name);
 #endif
@@ -4718,7 +4719,7 @@ void clean_playerfile() {
           }
         }
       }
-    } /* while */
+    } * while *
   } else {
     mudlog(LOG_ERROR, "Error opening dir %s.", PLAYERS_DIR);
   }
@@ -4727,7 +4728,7 @@ void clean_playerfile() {
   mudlog(LOG_CHECK, "-- %d characters deleted.  ", num_deleted);
   mudlog(LOG_CHECK, "-- %d gods demoted due to inactivity.", num_demoted);
   mudlog(LOG_CHECK, "Cleaning done.");
-}
+} */
 
 #if ENABLE_AUCTION
 

--- a/src/db.c
+++ b/src/db.c
@@ -210,10 +210,12 @@ void boot_db() {
   else
     wizhelp_index = build_help_index(wizhelp_fl, &top_of_wizhelpt);
 
-/*#if CLEAN_AT_BOOT
+#if CLEAN_AT_BOOT
   mudlog(LOG_CHECK, "Clearing inactive players");
   clean_playerfile();
-#endif*/
+#else
+  mudlog(LOG_CHECK, "Skipping inactive players check");
+#endif
 
   mudlog(LOG_CHECK, "Booting mail system.");
   if (!scan_mail_file()) {
@@ -4559,7 +4561,7 @@ void ConvertPlayerFile(void) {
 
 
 
-/*void clean_playerfile() {
+void clean_playerfile() {
 
   struct junk {
     struct char_file_u dummy;
@@ -4580,9 +4582,9 @@ void ConvertPlayerFile(void) {
   timeH = time(0);
 
   mudlog(LOG_SYSERR, "time now %i", timeH);
-  * Probabilmente questa si puo eliminare
+  /* Probabilmente questa si puo eliminare 
    
-     ConvertPlayerFile();*
+     ConvertPlayerFile();*/
 
   if ((dir = opendir(PLAYERS_DIR)) != NULL) {
     while ((ent = readdir(dir)) != NULL) {
@@ -4610,14 +4612,14 @@ void ConvertPlayerFile(void) {
              mudlog(LOG_SYSERR,"Nome: %s",grunt.dummy.name);
             num_processed++;
 
-            * Fa la lista dei personaggi attivi.. a bit tedious *
+            /* Fa la lista dei personaggi attivi.. a bit tedious */
             char *classname[] = {"Mu", "Cl", "Wa", "Th", "Dr", "Mo", "Ba", "So", "Pa","Ra", "Ps", "?", "??"};
             char classes[100];
             classes[0] = '\0';
             int i;
 
             for (i = max = 0; i < MAX_CLASS; i++) {
-              *calcola il livello piu` alto in max*
+              /*calcola il livello piu` alto in max*/
               if (grunt.dummy.level[ i ] > max)
                 max = grunt.dummy.level[ i ];
 
@@ -4634,7 +4636,7 @@ void ConvertPlayerFile(void) {
                       grunt.dummy.name,
                       classes, grunt.dummy.points.max_hit);
             }
-              
+
             if (max < IMMORTALE) {
               j = (int) max;
               if (j < 5)
@@ -4642,8 +4644,8 @@ void ConvertPlayerFile(void) {
 
               age = timeH - grunt.dummy.last_logon;
 
-              mudlog(LOG_SYSERR, "*****%s****Last logon: %i***tempo intercorso-->%i", grunt.dummy.name, grunt.dummy.last_logon, age);
-              mudlog(LOG_SYSERR, "*****%s", grunt.dummy.description); */
+              mudlog(LOG_SYSERR, "*****%s****Last logon: %i***age-->%i", grunt.dummy.name, grunt.dummy.last_logon, age);
+              mudlog(LOG_SYSERR, "*****%s", grunt.dummy.description);
               
               
               /* BUG BUG BUG */
@@ -4667,7 +4669,7 @@ void ConvertPlayerFile(void) {
                 }
               } */
                 
-              /* Avviso di cancellazione imminente *
+              /* Avviso di cancellazione imminente*/
 
               if (!grunt.AXE && age > (long) (j - 1) * (SECS_PER_REAL_DAY * 7) && !IS_SET(grunt.dummy.user_flags, NO_DELETE)) {
                 num_warned++;
@@ -4689,7 +4691,7 @@ void ConvertPlayerFile(void) {
             fclose(pFile);
 
             if (grunt.AXE) {
-#ifndef NOREGISTER	 */
+#ifndef NOREGISTER	 
 
               /*******
               Flyp: cancellazione da riverificare
@@ -4709,7 +4711,6 @@ void ConvertPlayerFile(void) {
               system( buf );
               mudlog(LOG_CHECK,"%s cancellato per inattivita'",grunt.dummy.name);
                *************/
-/*
 #else
               mudlog(LOG_CHECK, "%s doveva essere cancellato", grunt.dummy.name);
 #endif
@@ -4719,7 +4720,7 @@ void ConvertPlayerFile(void) {
           }
         }
       }
-    } * while *
+    } /* while */
   } else {
     mudlog(LOG_ERROR, "Error opening dir %s.", PLAYERS_DIR);
   }
@@ -4728,7 +4729,7 @@ void ConvertPlayerFile(void) {
   mudlog(LOG_CHECK, "-- %d characters deleted.  ", num_deleted);
   mudlog(LOG_CHECK, "-- %d gods demoted due to inactivity.", num_demoted);
   mudlog(LOG_CHECK, "Cleaning done.");
-} */
+}
 
 #if ENABLE_AUCTION
 

--- a/src/snew.h
+++ b/src/snew.h
@@ -8,7 +8,7 @@
 #ifndef __SNEW
 #define __SNEW 1
 #define CHECK_RENT_INACTIVE 1
-#define CLEAN_AT_BOOT 1
+#define CLEAN_AT_BOOT false
 #define NEW_ALIGN 1
 #define MARKS(s) SetLine(s,__LINE__)
 #define MARK SetLine(__FILE__,__LINE__)

--- a/src/utility.c
+++ b/src/utility.c
@@ -1046,11 +1046,13 @@ void age2(struct char_data *ch, struct time_info_data *g)
   g->ayear=g->year; /* QUi resta l'eta' anagrafica */
   g->year = MAX(17,g->ayear+ch->AgeModifier); /* Qui l'eta' effettiva */
    
-   /* I principi non invecchiano oltre un certo limite*/
-   if (IS_PRINCE(ch)) 
-   {
+/* I principi non invecchiavano oltre un certo limite, poi abbiamo esteso questa procedura a tutti */
+//if (IS_PRINCE(ch))
+//{
       g->year=(MIN(g->year,50));
-   }
+      g->ayear=g->year;
+//}
+    
    
   
 }


### PR DESCRIPTION
L'age ora non avanza oltre i 50 anni(relativi alla razza), il buffer per l'accesso e' stato esteso per permettere al mud di proseguire nel login.

la modifica dell'age si applica permanentemente nel momento in cui l'utente entra e fa save o rent. In tal modo in futuro, potremo individuare chi non gioca proprio piu' anche solo dall'eta' del pg. Vabbe' che va finita la procedura di enrico, ma intanto penso vada bene.

Rispetto all'interruzione del ./myst nel momento in cui tutti i pg sono nella cartella(mi pare siano piu' di 1000), è bastato commentare completamente la clean_playerfile() che si occupa di deletare i pg inattivi e che e' per ora bacata.

foto relative: https://www.dropbox.com/sh/iz9ilmi2u2t21yu/AAANqKFaJPc6CFNm9ZqFfXtba?dl=0