### PR TITLE
skill "Parry" fixed, spell "darkness" ora editabile

### DIFF
--- a/src/_fight.c
+++ b/src/_fight.c
@@ -205,7 +205,7 @@ int Hit_Location(struct char_data *victim)
 
    /* Check su PARRY e generate random hit location */
 
-    if(IS_SET(victim->specials.affected_by,AFF_PARRY))
+    if(IS_SET(victim->specials.affected_by2, AFF2_PARRY))
 
    {
 
@@ -584,9 +584,9 @@ void stop_fighting(struct char_data *ch)
 
    /* Rimuovo il flag PARRY Gaia 7/2000 */
 
-   if(IS_SET( ch->specials.affected_by, AFF_PARRY ) )
+   if(IS_SET( ch->specials.affected_by2, AFF2_PARRY ) )
    {
-      REMOVE_BIT( ch->specials.affected_by, AFF_PARRY );
+      REMOVE_BIT( ch->specials.affected_by2, AFF2_PARRY );
       act( "$n smette di proteggersi con lo scudo.", FALSE, ch, 0, 0, TO_ROOM );
       act( "Smetti di proteggerti con lo scudo.", FALSE,ch, 0, 0, TO_CHAR );
    }  
@@ -1099,9 +1099,9 @@ void raw_kill(struct char_data *ch,int killedbytype)
 
    /* Rimuovo anche il flag del PARRY Gaia 7/2000 */
 
-   if (IS_SET(ch->specials.affected_by,AFF_PARRY))
+   if (IS_SET(ch->specials.affected_by2, AFF2_PARRY))
    {
-      REMOVE_BIT(ch->specials.affected_by,AFF_PARRY);
+      REMOVE_BIT(ch->specials.affected_by2, AFF2_PARRY);
    }
 
  
@@ -3397,7 +3397,7 @@ DamageResult root_hit( struct char_data *ch, struct char_data *orig_victim,
       se il pg e' in parry il mob non perde move 
       Gaia 7/2000 */   
 
-   if ( !IS_SET(victim->specials.affected_by,AFF_PARRY) ) 
+   if ( !IS_SET(victim->specials.affected_by2, AFF2_PARRY) ) 
     {
    GET_MOVE(ch) -=1; alter_move(ch,0);
     }
@@ -3480,7 +3480,7 @@ void PCAttacks( char_data *pChar )
       ma i suoi attacchi calcolati sono aumentati di uno.
       Gaia (7/2000) */
 
-   if (IS_SET(pChar->specials.affected_by,AFF_PARRY))
+   if (IS_SET(pChar->specials.affected_by2, AFF2_PARRY))
     { 
 
      if (HasClass( pChar, CLASS_RANGER ) && DUAL_WIELD(pChar) )
@@ -3594,7 +3594,7 @@ void PCAttacks( char_data *pChar )
    /* check for the second attack */
    /* Se sei in parry non puoi usare il dual wield Gaia 7/2000 */
    if( DUAL_WIELD( pChar ) && pChar->skills
-       && !IS_SET(pChar->specials.affected_by,AFF_PARRY) )
+       && !IS_SET(pChar->specials.affected_by2, AFF2_PARRY) )
    {
       /* check the skill */
       if( ( perc = number( 1, 101 ) ) <

--- a/src/act.info.c
+++ b/src/act.info.c
@@ -834,22 +834,21 @@ void show_char_to_char( struct char_data *i, struct char_data *ch, int mode )
     
     if( IS_AFFECTED( i, AFF_SANCTUARY ) )
     {
-      if( !affected_by_spell( i, SPELL_GLOBE_DARKNESS ) )
+      if( !IS_AFFECTED( i, AFF_GLOBE_DARKNESS ) )
 	act( "$c0015$n brilla di luce propria!", FALSE, i, 0, ch, TO_VICT ); 
     }
-
       
     if( IS_AFFECTED( i, AFF_GROWTH ) )
       act( "$c0003$n e` enorme!", FALSE, i, 0, ch, TO_VICT );
       
     if( IS_AFFECTED( i, AFF_FIRESHIELD ) )
     {
-      if( !affected_by_spell( i, SPELL_GLOBE_DARKNESS ) )    
+      if( !IS_AFFECTED( i, AFF_GLOBE_DARKNESS ) )
 	act( "$c0001$n e` avvolt$b in una luce fiammeggiante!", FALSE, i, 0, ch, 
 	     TO_VICT);
     }
 
-    if( affected_by_spell( i, SPELL_GLOBE_DARKNESS ) ) 
+    if( IS_AFFECTED( i, AFF_GLOBE_DARKNESS ) )
       act("$c0008$n e` avvolt$b nell'oscurita`!", FALSE, i, 0, ch, TO_VICT );
     
   }

--- a/src/act.off.c
+++ b/src/act.off.c
@@ -1720,9 +1720,9 @@ void do_parry( struct char_data *ch, char *arg, int cmd)
      di default finche il comando non viene ridato o il
      combattimento finisce */
  
- if (IS_SET(ch->specials.affected_by,AFF_PARRY)) {
+ if (IS_SET(ch->specials.affected_by2, AFF2_PARRY)) {
    send_to_char("Smetti di proteggerti con lo scudo.\n\r",ch);
-   REMOVE_BIT(ch->specials.affected_by,AFF_PARRY);
+   REMOVE_BIT(ch->specials.affected_by2, AFF2_PARRY);
    return;
   }
  
@@ -1730,7 +1730,7 @@ void do_parry( struct char_data *ch, char *arg, int cmd)
     viene controllato nelle routine di combat (fight.c) volta per volta. */
  
     if (GET_POS(victim) > POSITION_DEAD)     {
-         SET_BIT(ch->specials.affected_by,AFF_PARRY);
+         SET_BIT(ch->specials.affected_by2, AFF2_PARRY);
      act("$c1012$n cerca di proteggersi dai colpi usando lo scudo!", FALSE, ch, 0, victim, TO_ROOM);
      act("$c1012Cerchi di proteggerti con lo scudo.",FALSE,ch,0,0,TO_CHAR);
     }

--- a/src/checkfile.c
+++ b/src/checkfile.c
@@ -151,8 +151,8 @@ typedef struct alias_type
 #define AFF_FIRESHIELD        0x08000000
 #define AFF_GROUP             0x10000000
 #define AFF_TELEPATHY         0x20000000
-#define AFF_UNDEF_AFF_1       0x40000000
-#define AFF_UNDEF_AFF_2       0x80000000
+#define AFF_GLOBE_DARKNESS    0x40000000  /* Added by REQUIEM 2018 */
+#define AFF_UNDEF_AFF_1       0x80000000
 
 #define ACT_SPEC       (1<<0)  /* special routine to be called if exist   */
 #define ACT_SENTINEL   (1<<1)  /* this mobile not to be moved             */

--- a/src/comm.c
+++ b/src/comm.c
@@ -2695,6 +2695,10 @@ void save_all()
                               if( IS_SET( ch->immune,IMM_DRAIN ) || IS_SET( ch->M_immune,IMM_DRAIN ) )
                                 fa=1;
                               break;
+                              case SPELL_GLOBE_DARKNESS:
+                                if( IS_AFFECTED( ch, AFF_GLOBE_DARKNESS ) )
+                                  fa=1;
+                                break;
                             }
                             if( ch->affected )
                               for( hjp = ch->affected; hjp; hjp = hjp->next )

--- a/src/constants.c
+++ b/src/constants.c
@@ -2778,6 +2778,7 @@ const char *affected_bits[] =
   "FIRESHIELD",
   "GROUP",
   "TELEPATHY",
+  "DARKNESS",
   "\n"
 };
 
@@ -2787,6 +2788,7 @@ const char *affected_bits2[] =
   "Heat Stuff",
   "Logging",
   "Berserk",
+  "Parry",
   "Group-Order",
   "AWAY-FROM-KEYBOARD",
   "Pkilled someone",

--- a/src/db.c
+++ b/src/db.c
@@ -3550,8 +3550,8 @@ void reset_char(struct char_data *ch) {
   if (IS_SET(ch->specials.affected_by2, AFF2_BERSERK)) {
     REMOVE_BIT(ch->specials.affected_by2, AFF2_BERSERK);
   }
-  if (IS_SET(ch->specials.affected_by, AFF_PARRY)) {
-    REMOVE_BIT(ch->specials.affected_by, AFF_PARRY);
+  if (IS_SET(ch->specials.affected_by2, AFF2_PARRY)) {
+    REMOVE_BIT(ch->specials.affected_by2, AFF2_PARRY);
   }
   /*
    * Clear out MAILING flags case there was a crash

--- a/src/fight.c
+++ b/src/fight.c
@@ -205,7 +205,7 @@ int Hit_Location(struct char_data *victim)
 
    /* Check su PARRY e generate random hit location */
 
-    if(IS_SET(victim->specials.affected_by,AFF_PARRY))
+    if(IS_SET(victim->specials.affected_by2, AFF2_PARRY))
 
    {
 
@@ -584,9 +584,9 @@ void stop_fighting(struct char_data *ch)
 
    /* Rimuovo il flag PARRY Gaia 7/2000 */
 
-   if(IS_SET( ch->specials.affected_by, AFF_PARRY ) )
+   if(IS_SET( ch->specials.affected_by2, AFF2_PARRY ) )
    {
-      REMOVE_BIT( ch->specials.affected_by, AFF_PARRY );
+      REMOVE_BIT( ch->specials.affected_by2, AFF2_PARRY );
       act( "$n smette di proteggersi con lo scudo.", FALSE, ch, 0, 0, TO_ROOM );
       act( "Smetti di proteggerti con lo scudo.", FALSE,ch, 0, 0, TO_CHAR );
    }  
@@ -1099,9 +1099,9 @@ void raw_kill(struct char_data *ch,int killedbytype)
 
    /* Rimuovo anche il flag del PARRY Gaia 7/2000 */
 
-   if (IS_SET(ch->specials.affected_by,AFF_PARRY))
+   if (IS_SET(ch->specials.affected_by2, AFF2_PARRY))
    {
-      REMOVE_BIT(ch->specials.affected_by,AFF_PARRY);
+      REMOVE_BIT(ch->specials.affected_by2, AFF2_PARRY);
    }
 
  
@@ -3398,7 +3398,7 @@ DamageResult root_hit( struct char_data *ch, struct char_data *orig_victim,
       se il pg e' in parry il mob non perde move 
       Gaia 7/2000 */   
 
-   if ( !IS_SET(victim->specials.affected_by,AFF_PARRY) ) 
+   if ( !IS_SET(victim->specials.affected_by2, AFF2_PARRY) ) 
     {
    GET_MOVE(ch) -=1; alter_move(ch,0);
     }
@@ -3481,7 +3481,7 @@ void PCAttacks( char_data *pChar )
       ma i suoi attacchi calcolati sono aumentati di uno.
       Gaia (7/2000) */
 
-   if (IS_SET(pChar->specials.affected_by,AFF_PARRY))
+   if (IS_SET(pChar->specials.affected_by2, AFF2_PARRY))
     { 
 
      if (HasClass( pChar, CLASS_RANGER ) && DUAL_WIELD(pChar) )
@@ -3595,7 +3595,7 @@ void PCAttacks( char_data *pChar )
    /* check for the second attack */
    /* Se sei in parry non puoi usare il dual wield Gaia 7/2000 */
    if( DUAL_WIELD( pChar ) && pChar->skills
-       && !IS_SET(pChar->specials.affected_by,AFF_PARRY) )
+       && !IS_SET(pChar->specials.affected_by2, AFF2_PARRY) )
    {
       /* check the skill */
       if( ( perc = number( 1, 101 ) ) <

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -424,11 +424,11 @@ void command_interpreter( struct char_data *ch, char *argument )
 
  /* PARRY is removed as HIDE GAIA 2001 */
 
-   if(IS_AFFECTED(ch,AFF_PARRY))
+   if(IS_AFFECTED(ch,AFF2_PARRY))
    {
     act( "$c0006$n smette di ripararsi con lo scudo.", TRUE, ch, 0, 0, TO_ROOM);
     act( "$c0006Smetti di proteggerti con lo scudo.", TRUE, ch, 0, 0, TO_CHAR);
-      REMOVE_BIT( ch->specials.affected_by, AFF_PARRY );
+      REMOVE_BIT( ch->specials.affected_by2, AFF2_PARRY );
    }                                                                                      
 
    if (ch->listening_to)

--- a/src/magic2.c
+++ b/src/magic2.c
@@ -1758,11 +1758,13 @@ if (level >= MAESTRO) {                  /* if level 45> then they can do this *
    }
 
     if (affected_by_spell(victim,SPELL_GLOBE_DARKNESS)) {
-      if (yes || !saves_spell(victim, SAVING_SPELL) ) {    
+      if (yes || !saves_spell(victim, SAVING_SPELL) ) {
+         REMOVE_BIT(victim->specials.affected_by, AFF_GLOBE_DARKNESS);
          affect_from_char(victim,SPELL_GLOBE_DARKNESS);
          send_to_char("Il globo di oscurita' che ti avvolgeva scompare.\n\r",victim);
+         act("Il globo di oscurita' che avvolge $n si dissolve.",FALSE,victim,0,0,TO_ROOM);
       }
-    }    
+    }
     if (affected_by_spell(victim,SPELL_GLOBE_MINOR_INV)) {
       if (yes || !saves_spell(victim, SAVING_SPELL) ) {
          affect_from_char(victim,SPELL_GLOBE_MINOR_INV);
@@ -2422,7 +2424,7 @@ void spell_globe_darkness(byte level, struct char_data *ch,
     af.duration  = level;                  
     af.modifier  = 5;
     af.location  = APPLY_HIDE;
-    af.bitvector = 0;
+    af.bitvector = AFF_GLOBE_DARKNESS;
     affect_to_char(victim, &af);
   } else {
   if (ch != victim)

--- a/src/skills.c
+++ b/src/skills.c
@@ -2205,6 +2205,15 @@ void do_tan( struct char_data *ch, char *arg, int cmd)
                app_val = IMM_ENERGY ;
                }
                break ;
+               case RACE_GOD      :
+               if( total_bonus > 26 )
+               {
+               special = 1 ;
+               apply = APPLY_IMMUNE ;
+               app_val = IMM_BLUNT ;
+               }
+               break ;
+
                default:
                break;
               }

--- a/src/speciali.c
+++ b/src/speciali.c
@@ -859,12 +859,12 @@ int Nightmare( struct char_data *ch, int cmd, char *arg, struct char_data *mob, 
     af.bitvector = AFF_FIRESHIELD;
     affect_to_char(mob, &af);
   }
-  if(!affected_by_spell(mob, SPELL_GLOBE_DARKNESS)) {
+  if(!IS_AFFECTED(mob, AFF_GLOBE_DARKNESS)) {
 		af.type      = SPELL_GLOBE_DARKNESS;
   	af.duration  = 1;                  
     af.modifier  = 5;
     af.location  = APPLY_HIDE;
-    af.bitvector = 0;
+    af.bitvector = AFF_GLOBE_DARKNESS;
     affect_to_char(mob, &af);
   }
   

--- a/src/structs.h
+++ b/src/structs.h
@@ -910,8 +910,8 @@ struct room_data
 #define AFF_FIRESHIELD        0x08000000
 #define AFF_GROUP             0x10000000
 #define AFF_TELEPATHY         0x20000000
-#define AFF_PARRY             0x40000000  /* Added by GAIA 2001 */
-#define AFF_UNDEF_AFF_1       0x80000000
+#define AFF_GLOBE_DARKNESS    0x40000000  /* Added by REQUIEM 2018 */
+#define AFF_UNDEF_AFF_1       0x80000000  
 
 /* affects 2 */
 
@@ -919,9 +919,10 @@ struct room_data
 #define AFF2_HEAT_STUFF       0x00000002
 #define AFF2_LOG_ME           0x00000004
 #define AFF2_BERSERK          0x00000008
-#define AFF2_CON_ORDER        0x00000010
-#define AFF2_AFK              0x00000020
-#define AFF2_PKILLER          0x00000040
+#define AFF2_PARRY            0x00000010  /* Added by GAIA 2001 */
+#define AFF2_CON_ORDER        0x00000020
+#define AFF2_AFK              0x00000040
+#define AFF2_PKILLER          0x00000080
 /* modifiers to char's abilities */
 
 #define APPLY_NONE              0


### PR DESCRIPTION
Ho spostato la skill Parry negli AFF2 insieme al berserk, che è la skill di tipologia piu' simile essendone l'esatto opposto. Ora risponde
correttamente in combat, e mi ha lasciato uno slot libero negli AFF1 che ho riempito con quanto segue:

Dallo storico listino degli edit risulta la possibilità di editare uno slot con spell affected by "darkness", utilissimo per non scrappare oggetti anti-sun alla luce del giorno, ed essendo un affected-by da eq non dispellabile ha sempre fatto piangere tutti la sua mancanza. Si potranno ora creare oggetti con tale affect per aree esistenti o nuove, ed è possibile editarlo tramite: 

ooedit nome_obj aff1 1073741824 29  -> dove il primo numero indica l'hex convertito in intero per puntare alla spell, e 29 il tipo di applicazione su slot.

inserita inoltre una send_to_room, per far apparire un messaggio quando il darkness(da spell, non da eq) viene rimosso tramite dispel magic: "Il globo di oscurita' che avvolge $n si dissolve."

foto: 
[https://www.dropbox.com/s/vxhl3stf09pxg3k/Schermata%202018-01-20%20alle%2005.34.25.png?dl=0](url)
[https://www.dropbox.com/s/ktk3md9hlg7cxf7/Schermata%202018-01-20%20alle%2005.36.35.png?dl=0](url)
