### PR TITLE
Fixed Skill Parry vs Detect Magic

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -3550,6 +3550,9 @@ void reset_char(struct char_data *ch) {
   if (IS_SET(ch->specials.affected_by2, AFF2_BERSERK)) {
     REMOVE_BIT(ch->specials.affected_by2, AFF2_BERSERK);
   }
+  /*
+   * Clear out Parry flags case there was a crash in a fight
+   */
   if (IS_SET(ch->specials.affected_by2, AFF2_PARRY)) {
     REMOVE_BIT(ch->specials.affected_by2, AFF2_PARRY);
   }

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -424,7 +424,7 @@ void command_interpreter( struct char_data *ch, char *argument )
 
  /* PARRY is removed as HIDE GAIA 2001 */
 
-   if(IS_AFFECTED(ch,AFF2_PARRY))
+   if(IS_AFFECTED2(ch,AFF2_PARRY) && !ch->specials.fighting)
    {
     act( "$c0006$n smette di ripararsi con lo scudo.", TRUE, ch, 0, 0, TO_ROOM);
     act( "$c0006Smetti di proteggerti con lo scudo.", TRUE, ch, 0, 0, TO_CHAR);


### PR DESCRIPTION
Rivista la skill parry per prevenire alcune stringhe relative al parry che spuntavano fuori se affetti da detect magic.

Aggiunto un commento in db.c