### PR TITLE
druid-balancing

### DIFF
--- a/src/protos.h
+++ b/src/protos.h
@@ -976,7 +976,7 @@ void spell_shillelagh(byte level, struct char_data *ch,
   struct char_data *victim, struct obj_data *obj);
 void spell_goodberry(byte level, struct char_data *ch,
   struct char_data *victim, struct obj_data *obj);
-void spell_flame_blade(byte level, struct char_data *ch,
+void spell_elemental_blade(byte level, struct char_data *ch,
   struct char_data *victim, struct obj_data *obj);
 void spell_animal_growth(byte level, struct char_data *ch,
   struct char_data *victim, struct obj_data *obj);
@@ -1798,7 +1798,7 @@ void cast_shillelagh( byte level, struct char_data *ch, char *arg,
      int type, struct char_data *tar_ch, struct obj_data *tar_obj );
 void cast_goodberry( byte level, struct char_data *ch, char *arg,
      int type, struct char_data *tar_ch, struct obj_data *tar_obj );
-void cast_flame_blade( byte level, struct char_data *ch, char *arg,
+void cast_elemental_blade( byte level, struct char_data *ch, char *arg,
      int type, struct char_data *tar_ch, struct obj_data *tar_obj );
 void cast_animal_growth( byte level, struct char_data *ch, char *arg,
      int type, struct char_data *tar_ch, struct obj_data *tar_obj );

--- a/src/spec_procs2.c
+++ b/src/spec_procs2.c
@@ -4978,7 +4978,7 @@ int DruidChallenger(struct char_data *ch, int cmd, char *arg, struct char_data *
       if (!ch->equipment[WIELD]) {
 	 if (GetMaxLevel(ch) > 4) {
 	    act("$n pronuncia le parole 'gimme a light'", 1, ch, 0, 0, TO_ROOM);
-	    cast_flame_blade(GetMaxLevel(ch), ch, "", SPELL_TYPE_SPELL, ch, 0);
+	    cast_elemental_blade(GetMaxLevel(ch), ch, "", SPELL_TYPE_SPELL, ch, 0);
 	 }
 	 return(TRUE);
       }
@@ -5183,7 +5183,7 @@ int druid( struct char_data *ch, int cmd, char *arg, struct char_data *mob,
               GET_DAMROLL( ch ) ) < 16 )
 	 {
 	    act("$n pronuncia le parole 'gimme a light'", 1, ch, 0, 0, TO_ROOM);
-	    cast_flame_blade(GetMaxLevel(ch), ch, "", SPELL_TYPE_SPELL, ch, 0);
+	    cast_elemental_blade(GetMaxLevel(ch), ch, "", SPELL_TYPE_SPELL, ch, 0);
 	    return(TRUE);
 	 }
       }

--- a/src/spell_list.h
+++ b/src/spell_list.h
@@ -2188,7 +2188,7 @@ spello(123,
 /*align       */ 0,
 /*ostile      */ 0);
 
-/* cast_flame_blade */
+/* cast_elemental_blade */
 spello(124,
 /*beats       */ 12,
 /*min position*/ POSITION_STANDING,
@@ -2201,7 +2201,7 @@ spello(124,
 /*psIonic     */ IMMORTALE,
 /*mana        */ 10,
 /*target      */ TAR_IGNORE,
-/*funzione    */ cast_flame_blade,
+/*funzione    */ cast_elemental_blade,
 /*spell fail  */ 0,
 /*align       */ 0,
 /*ostile      */ 0);

--- a/src/spell_parser.c
+++ b/src/spell_parser.c
@@ -167,7 +167,7 @@ char *spells[]=
    "feeblemind",
    "shillelagh",
    "goodberry",
-   "flame blade",
+   "elemental blade",
    "animal growth",
    "insect growth",
    "creeping death",

--- a/src/spells.h
+++ b/src/spells.h
@@ -161,7 +161,7 @@ typedef char byte;
 /* druid... */
 #define SPELL_SHILLELAGH            122
 #define SPELL_GOODBERRY             123
-#define SPELL_FLAME_BLADE           124
+#define SPELL_ELEMENTAL_BLADE           124
 #define SPELL_ANIMAL_GROWTH         125
 #define SPELL_INSECT_GROWTH         126
 #define SPELL_CREEPING_DEATH        127

--- a/src/spells2.c
+++ b/src/spells2.c
@@ -3426,7 +3426,7 @@ void cast_goodberry( byte level, struct char_data *ch, char *arg,
 }
 
 
-void cast_flame_blade( byte level, struct char_data *ch, char *arg,
+void cast_elemental_blade( byte level, struct char_data *ch, char *arg,
                        int type, struct char_data *tar_ch, 
                        struct obj_data *tar_obj )
 {
@@ -3435,7 +3435,7 @@ void cast_flame_blade( byte level, struct char_data *ch, char *arg,
   {
    case SPELL_TYPE_SPELL:
    case SPELL_TYPE_SCROLL:
-    spell_flame_blade(level, ch, ch, 0);
+    spell_elemental_blade(level, ch, ch, 0);
     break;
    default:
     mudlog( LOG_SYSERR, "serious screw-up in flame blade.");


### PR DESCRIPTION
Ho pensato di apportare due modifiche che ho visto su ts2 anche da noi, per la classe Druido:

- transport via plant: da noi puoi usarlo solo da pianta a pianta, molto scomodo e mai usato visto che ci sono 6 o 7 alberi in tutto, ed al 51 si prende doorway. Ho replicato come su ts2 la possibilità di trasportarsi verso quell'albero da qualsiasi zona all'aperto. Dal punto di vista Rpg ho rettificato le stringhe a:

per gli altri nella stanza di partenza: "$n tocca il suolo per percepire $p, e viene assorbito dalla terra!"
per il pg nella stanza di partenza: "Percepisci $p, e come acqua ti lasci guidare dalla terra alle sue radici."
per gli altri nella stanza di arrivo: "$p si squote leggermente, e $n aparre magicamente dal suo interno!"
per il pg nella stanza di arrivo: "Vieni trasportat$b istantaneamente da $p!"

...e dato un tocco di verde.

flame blade ora è elemental blade:

inserito una randomizzazione da 0 a 2, a seconda del caso restituisce una flame blade, una frost blade o una thunder blade.
per caratterizzarle dal punto di vista elementale ho aggiunto un weapon spell, rispettivamente flamestrike, chill touch, lightning bolt.

Visto che ho inserito la spell ho ridotto il damroll calcolato in base al livello. Ora si parte da una base di 3, ad un massimo di +5 al Lev. 51... prima arrivava a 9damroll -_-

Se accettate questa modifica non resta che da rettificare l'help, a cui io non ho ancora accesso essendo questo nell'area builders.

foto:
https://www.dropbox.com/s/nmu1z3j0iq58cqk/Schermata%202018-01-22%20alle%2004.56.24.png?dl=0
https://www.dropbox.com/s/wi7umqjh0nxstb9/Schermata%202018-01-22%20alle%2005.32.16.png?dl=0
https://www.dropbox.com/s/bv6jt4qxgdb3yli/Schermata%202018-01-22%20alle%2005.37.47.png?dl=0