### PR TITLE
Convertita immu Hold in resistenza per Lizardman

### DIFF
--- a/src/skills.c
+++ b/src/skills.c
@@ -2277,7 +2277,7 @@ void do_tan( struct char_data *ch, char *arg, int cmd)
                       if( total_bonus > 23 )
                       {
                           special = 1 ;
-                          apply = APPLY_M_IMMUNE ;
+                          apply = APPLY_IMMUNE ;
                           app_val = IMM_HOLD ;
                       }
                       break ;


### PR DESCRIPTION
Ora la pelle di Lizardman dara' resi hold anziche' immu. Da notare che il codice le divide in IMMU ed M_IMMU, quindi
non pensate a un errore se non trovate RESI