### PR TITLE
stampa sintassi di pquest, se usato erroneamente

### DIFF
--- a/src/act.obj1.c
+++ b/src/act.obj1.c
@@ -1372,7 +1372,9 @@ if (punti_quest <0)
 	}
   }
   else
-      send_to_char( "Non hai ben chiaro il valore delle cose.\n\r", ch );
+      send_to_char( "Non hai ben chiaro il valore delle cose... lascia che ti rinfreschi la memoria:\n\n\r", ch );
+      send_to_char( "pquest 0 target        per conoscere i pq\n\r", ch );
+      send_to_char( "pq valore trarget      per assegnare/rimuovere pquest\n\n\r", ch );
   return;
 }
 


### PR DESCRIPTION
Ad un uso scorretto del comando pquest, si ottiene la sintassi insieme al messaggio d'errore