### PR TITLE
Fix per il gain bug e traduzione

### DIFF
--- a/src/maximums.cpp
+++ b/src/maximums.cpp
@@ -501,11 +501,6 @@ int move_gain(struct char_data* ch)
 int GetHpGain(struct char_data* ch, int iClass,int livello,int compat,int check=0) {
 	int add_hp;
 
-	if (IS_PRINCE(ch)&&check==0) {
-		mudlog(LOG_PLAYERS, "%s sta tentando di sfruttare il bug gain hp", GET_NAME(ch));
-		return(-1);
-	}
-
 	if (livello>=CHUMP) {
 		if (iClass == WARRIOR_LEVEL_IND || iClass == BARBARIAN_LEVEL_IND ||
 				iClass == PALADIN_LEVEL_IND || iClass == RANGER_LEVEL_IND)
@@ -643,7 +638,7 @@ void advance_level(struct char_data* ch, int iClass)
 
 /* Gain maximum in various points */
 {
-	int add_hp, i, check_hp;
+	int i, check_hp;
 
 
 	if (iClass > MAX_CLASS) {
@@ -664,12 +659,8 @@ void advance_level(struct char_data* ch, int iClass)
 	check_hp=GetHpGain(ch,iClass,GET_LEVEL(ch,iClass),0);
 
 	if (check_hp != -1) {
-		//add_hp=GetHpGain(ch,iClass,GET_LEVEL(ch,iClass),0);
+		
 		ch->points.max_hit += MAX( 1, check_hp );
-	}
-	else {
-		send_to_char("Spero sia un errore... comunque il tuo tentativo di sfruttare il bug del gain e' stato loggato e non hai guadagnato nessun hp! Scrivi una mail di pentimento ad Elei o Jethro per evitare spiacevoli conseguenze!", ch);
-
 	}
 
 	if( ch->specials.spells_to_learn < 100 )

--- a/src/spec_procs.cpp
+++ b/src/spec_procs.cpp
@@ -124,19 +124,19 @@ int GainLevel(struct char_data* ch, int iClass) {
 #endif
 	if (GET_EXP(ch)>=
 			titles[iClass][GET_LEVEL(ch, iClass)+1].exp) {
-		if (GET_LEVEL(ch, iClass) < RacialMax[GET_RACE(ch)][iClass]) {
+		if (GET_LEVEL(ch, iClass) < RacialMax[GET_RACE(ch)][iClass] && !IS_PRINCE(ch)) {
 
-			send_to_char("You raise a level!\n\r", ch);
+			send_to_char("Cresci di un livello!\n\r", ch);
 			advance_level(ch, iClass);
 			set_title(ch);
 			return(TRUE);
 		}
 		else {
-			send_to_char("You are unable to advance further in this class\n\r", ch);
+			send_to_char("Non puoi avanzare oltre in questa classe\n\r", ch);
 		}
 	}
 	else {
-		send_to_char("You haven't got enough experience!\n\r",ch);
+		send_to_char("Non hai abbastanza punti esperienza!\n\r",ch);
 	}
 	return(FALSE);
 }


### PR DESCRIPTION
Ho rimosso gli avvisi dal maximums.cpp, applicando direttamente un check alla procedura speciale invocata prima del gain. Ora se
un 50 o superiore tenta il gain gli viene palesato che non può avanzare oltre in quella classe.

tradotti i messaggi in inglese.