### PR TITLE
Merge back release Hot fix Crash sull'invio delle mail (ticket #73)

### DIFF
--- a/quick.sh
+++ b/quick.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Utilizzato dal sistema di deploy.
+# In ambiente di sviluppo va lanciato solo se si aggiunge un nuovo file
+cd $(dirname "$0")
+make
+if [ -x src/myst ] ; then
+	cp src/myst mudroot/myst
+	exit 0
+fi
+exit 1
+

--- a/src/mail.cpp
+++ b/src/mail.cpp
@@ -106,10 +106,10 @@ int        _parse_name(char* arg, char* name);
 
 mail_index_type*                mail_index = 0; /* list of recs in the mail file  */
 position_list_type*         free_list = 0;  /* list of free positions in file */
-long        file_end_pos = 0; /* length of file */
+int        file_end_pos = 0; /* length of file */
 
 
-void        push_free_list(long pos) {
+void        push_free_list(int pos) {
 	position_list_type* new_pos;
 
 	new_pos = (position_list_type* )malloc(sizeof(position_list_type));
@@ -120,9 +120,9 @@ void        push_free_list(long pos) {
 
 
 
-long        pop_free_list(void) {
+int pop_free_list(void) {
 	position_list_type* old_pos;
-	long        return_value;
+	int        return_value;
 
 	if ((old_pos = free_list) != 0) {
 		return_value = free_list->position;
@@ -156,7 +156,7 @@ mail_index_type* find_char_in_index(char* searchee) {
 
 
 
-void        write_to_file(void* buf, int size, long filepos) {
+void        write_to_file(void* buf, int size, int filepos) {
 	FILE* mail_file;
 
 	mail_file = fopen(MAIL_FILE, "r+b");
@@ -178,7 +178,7 @@ void        write_to_file(void* buf, int size, long filepos) {
 }
 
 
-void        read_from_file(void* buf, int size, long filepos) {
+void        read_from_file(void* buf, int size, int filepos) {
 	FILE* mail_file;
 
 	mail_file = fopen(MAIL_FILE, "r+b");
@@ -198,7 +198,7 @@ void        read_from_file(void* buf, int size, long filepos) {
 
 
 
-void        index_mail(char* raw_name_to_index, long pos) {
+void        index_mail(char* raw_name_to_index, int pos) {
 	mail_index_type*      new_index;
 	position_list_type*   new_position;
 	char        name_to_index[100]; /* I'm paranoid.  so sue me. */
@@ -216,7 +216,7 @@ void        index_mail(char* raw_name_to_index, long pos) {
 
 	if (!(new_index = find_char_in_index(name_to_index))) {
 		/* name not already in index.. add it */
-		new_index = (mail_index_type* )malloc(sizeof(mail_index_type));
+		new_index = (mail_index_type* ) malloc(sizeof(mail_index_type));
 		strncpy(new_index->recipient, name_to_index, NAME_SIZE);
 		new_index->recipient[strlen(name_to_index)] = '\0';
 		new_index->list_start = 0;
@@ -227,7 +227,7 @@ void        index_mail(char* raw_name_to_index, long pos) {
 	}
 
 	/* now, add this position to front of position list */
-	new_position = (position_list_type* )malloc(sizeof(position_list_type));
+	new_position = (position_list_type* ) malloc(sizeof(position_list_type));
 	new_position->position = pos;
 	new_position->next = new_index->list_start;
 	new_index->list_start = new_position;
@@ -238,6 +238,7 @@ void        index_mail(char* raw_name_to_index, long pos) {
 /* scan_file is called once during boot-up.  It scans through the mail file
    and indexes all entries currently in the mail file. */
 int scan_mail_file(void) {
+
 	FILE*                     mail_file;
 	header_block_type  next_block;
 	int        total_messages = 0, block_num = 0;
@@ -290,8 +291,8 @@ int        has_mail(char* recipient) {
 void        store_mail(char* to, char* from, char* message_pointer) {
 	header_block_type          header;
 	data_block_type                data;
-	long        last_address, target_address;
-	char*        msg_txt = message_pointer;
+	int        last_address, target_address;
+	const char*        msg_txt = message_pointer;
 	char*        tmp;
 	int        bytes_written = 0;
 	int        total_length = strlen(message_pointer);
@@ -390,7 +391,7 @@ char*        read_delete(char* recipient, char* recipient_formatted)
 	data_block_type                data;
 	mail_index_type*                  mail_pointer, *prev_mail;
 	position_list_type*          position_pointer;
-	long        mail_address, following_block;
+	int        mail_address, following_block;
 	char*        message, *tmstr, buf[200];
 	size_t                        string_size;
 
@@ -445,8 +446,8 @@ char*        read_delete(char* recipient, char* recipient_formatted)
 		mudlog( LOG_SYSERR, "Mail system disabled!  -- Error #9.");
 		return 0;
 	}
-
-	tmstr = asctime(localtime(&header.mail_time));
+	time_t mtime=static_cast<time_t>(header.mail_time);
+	tmstr = asctime(localtime(&mtime));
 	*(tmstr + strlen(tmstr) - 1) = '\0';
 
 	sprintf(buf, " * * * * * * La posta di Nebbie Arcane * * * * * *\n\r"

--- a/src/mail.hpp
+++ b/src/mail.hpp
@@ -21,6 +21,10 @@
 
 /* command numbers of the "mail", "check", and "receive" commands
    in your interpreter. */
+#include "general.hpp"
+#include <iostream>
+#include <ostream>
+using std::string;
 #define CMD_MAIL        366
 #define CMD_CHECK        367
 #define CMD_RECEIVE        368
@@ -64,10 +68,10 @@ char*        read_delete(char* recipient, char* recipient_formatted);
 #define CHAR_SIZE sizeof(char)
 #define LONG_SIZE sizeof(long)
 
-#define HEADER_BLOCK_DATASIZE (BLOCK_SIZE-1-((CHAR_SIZE*(NAME_SIZE+1)*2)+(3*LONG_SIZE)))
+#define HEADER_BLOCK_DATASIZE (BLOCK_SIZE-1-((CHAR_SIZE*(NAME_SIZE+1)*2)+(3*INT_SIZE)))
 /* size of the data part of a header block */
 
-#define DATA_BLOCK_DATASIZE (BLOCK_SIZE-LONG_SIZE-1)
+#define DATA_BLOCK_DATASIZE (BLOCK_SIZE-INT_SIZE-1)
 /* size of the data part of a data block */
 
 /* note that an extra space is allowed in all string fields for the
@@ -81,37 +85,33 @@ char*        read_delete(char* recipient, char* recipient_formatted);
    them here because we have to be able to differentiate a data block from a
    header block when booting mail system.
 */
-
-struct header_block_type_d {
-	long        block_type;          /* is this a header block or data block? */
-	long        next_block;        /* if header block, link to next block   */
+#pragma pack(push,4)
+struct header_block_type {
+	int        block_type;          /* is this a header block or data block? */
+	int        next_block;        /* if header block, link to next block   */
 	char        from[NAME_SIZE+1]; /* who is this letter from?                 */
 	char        to[NAME_SIZE+1];/* who is this letter to?                 */
-	long        mail_time;        /* when was the letter mailed?                 */
+	int        mail_time;        /* when was the letter mailed?                 */
 	char        txt[HEADER_BLOCK_DATASIZE+1]; /* the actual text        */
 };
-
-struct data_block_type_d {
-	long        block_type;          /* -1 if header block, -2 if last data block
+struct data_block_type {
+	int        block_type;          /* -1 if header block, -2 if last data block
                                          in mail, otherwise a link to the next */
 	char        txt[DATA_BLOCK_DATASIZE+1]; /* the actual text                 */
 };
+#pragma pack(pop)
+static_assert (sizeof(data_block_type)==BLOCK_SIZE,"Check align, data_block_tpe size is wrong");
+static_assert (sizeof(header_block_type)==BLOCK_SIZE,"Check align, header_block_tpe size is wrong");
 
-typedef struct header_block_type_d header_block_type;
-typedef struct data_block_type_d data_block_type;
-
-struct position_list_type_d {
-	long        position;
-	struct position_list_type_d* next;
+struct position_list_type {
+	int        position;
+	struct position_list_type* next;
 };
 
-typedef struct position_list_type_d position_list_type;
 
-struct mail_index_type_d {
+struct mail_index_type {
 	char        recipient[NAME_SIZE+1]; /* who the mail is for */
 	position_list_type*             list_start;  /* list of mail positions    */
-	struct mail_index_type_d* next;
+	struct mail_index_type* next;
 };
-
-typedef struct mail_index_type_d mail_index_type;
 

--- a/src/signals.cpp
+++ b/src/signals.cpp
@@ -11,7 +11,7 @@
 #include "status.hpp"
 /* La ridefinizione di funzioni di memoria qui causerebbe ricorsione
  * */
-#define LOG_CRASH 1 // SALVO rimetto il controllo dei crash
+#define LOG_CRASH 0 // Alar, abbiamo gdb, meglio non modificare i crash
 #define MAX_FNAME_LEN 32
 #define STACK_SIZE 15
 int HowManyConnection(int ToAdd);


### PR DESCRIPTION
* Removed crash interception

When analyzing crash with gdb having a crash signal masked is nto useful

* Fix: #73 3rd crash

Passando a 64 bit è cambiato il padding nelle strutture , che adesso
devono essere multiple di 8 e non di 4.
La dimensione 100 dei blocchi usati dal mail system non è multipla di 8,
MA modificarla rompeva la struttura del file
Risolto con dei pragma di compilazione che forzano l'align a 4

* Changed internal values to int to respect exixstent file format

Also added a cast for time structure time_t