### PR TITLE
align check disabled  for mobs

### DIFF
--- a/src/handler.cpp
+++ b/src/handler.cpp
@@ -1189,7 +1189,7 @@ void equip_char(struct char_data* ch, struct obj_data* obj, int pos) {
 			return;
 		}
 
-		if( ItemAlignClash(ch, obj) && (GetMaxLevel(ch) < MAESTRO_DEI_CREATORI)) {
+		if( !IS_NPC(ch) && ItemAlignClash(ch, obj) && (GetMaxLevel(ch) < MAESTRO_DEI_CREATORI)) {
 			if (ch->in_room != NOWHERE) {
 				act( "You are zapped by $p and instantly drop it.", FALSE, ch, obj, 0,
 					 TO_CHAR);


### PR DESCRIPTION
- I mob druidi non lasciano piu' tutte le blade in giro