### PR TITLE
fix per mob dr + newhaste

### DIFF
--- a/src/act.move.cpp
+++ b/src/act.move.cpp
@@ -294,6 +294,10 @@ int RawMove(struct char_data* ch, int dir, int bCheckSpecial) {
 		need_movement = (movement_loss[from_here->sector_type]
 				+ movement_loss[to_here->sector_type]) / 2;
 	}
+    
+    if (affected_by_spell(ch, SPELL_HASTE)) {
+        need_movement = need_movement*4;
+    }
 
 	/*
 	 **   Movement in water_nowswim
@@ -335,6 +339,10 @@ int RawMove(struct char_data* ch, int dir, int bCheckSpecial) {
 				}
 			}
 		}
+        
+        if (affected_by_spell(ch, SPELL_HASTE)) {
+            need_movement = need_movement*4;
+        }
 	}
 
 	/*

--- a/src/fight.cpp
+++ b/src/fight.cpp
@@ -3181,6 +3181,7 @@ DamageResult hit(struct char_data* ch, struct char_data* victim,
 }
 
 void PCAttacks( char_data* pChar ) {
+    float sAttacks = pChar->mult_att;
 	float fAttacks = pChar->mult_att;
 	struct obj_data* pTmp = NULL;
 	struct obj_data* pWeapon = NULL; // SALVO la setto NULL mi serve per dopo
@@ -3229,6 +3230,21 @@ void PCAttacks( char_data* pChar ) {
 	}
 	/* work through all of their attacks, until there is not
 	 * a full attack left */
+
+    /* REQUIEM 2018 random haste */
+    
+    if (affected_by_spell(pChar, SPELL_HASTE)) {
+     
+        fAttacks += number(0.0,fAttacks);
+        mudlog(LOG_CHECK,"nuovo fAttacks = %f",fAttacks);
+        
+        if (fAttacks > sAttacks) {
+            mudlog(LOG_CHECK,"riduce il mov di = %d*10",((int)(fAttacks-sAttacks)));
+            GET_MOVE(pChar) -= 10*((int)(fAttacks-sAttacks));
+            alter_move(pChar, 0);
+        }
+        
+    }
 
 
 	if( DUAL_WIELD( pChar ) ) {

--- a/src/handler.cpp
+++ b/src/handler.cpp
@@ -561,16 +561,6 @@ void affect_modify(struct char_data* ch,byte loc, long mod, long bitv,bool add) 
 		break;
 
 	case APPLY_HASTE:
-		if (mod > 0) {
-			if (WizLock)
-			{ fprintf(stderr, "current mult = %f\n", ch->mult_att); }
-			ch->mult_att = ch->mult_att * 2.0;
-			if (WizLock)
-			{ fprintf(stderr, "new mult = %f\n", ch->mult_att); }
-		}
-		else if (mod < 0) {
-			ch->mult_att = ch->mult_att / 2.0;
-		}
 		break;
 
 	case APPLY_SLOW:

--- a/src/magic3.cpp
+++ b/src/magic3.cpp
@@ -304,14 +304,6 @@ void spell_haste(byte level, struct char_data* ch,
 	send_to_char("Perdi conoscenza\n\r",victim);
 	GET_POS(victim) = POSITION_STUNNED;
 
-	if (!IS_NPC(victim))
-	{ victim->player.time.birth -= SECS_PER_MUD_YEAR; }
-	else {
-		if (victim->desc && victim->desc->original)
-		{ victim->desc->original->player.time.birth -= SECS_PER_MUD_YEAR; }
-	}
-
-
 	if (!in_group(ch, victim)) {
 		if (!IS_PC(ch))
 		{ hit(victim, ch, TYPE_UNDEFINED); }

--- a/src/spec_procs2.cpp
+++ b/src/spec_procs2.cpp
@@ -1742,7 +1742,7 @@ int ninja_master(struct char_data* ch, int cmd, char* arg, struct char_data* mob
 				break;
 			case 2:
 				sk_num = SKILL_DOORBASH;
-				if( !HasClass( ch, CLASS_WARRIOR ) && !HasClass( ch, CLASS_PALADIN ) ) {
+				if( !HasClass( ch, CLASS_WARRIOR ) && !HasClass( ch, CLASS_PALADIN ) && !HasClass( ch, CLASS_RANGER ) ) {
 					send_to_char
 					("'You do not possess the necessary fighting skills'\n\r",ch);
 					return(TRUE);
@@ -4993,7 +4993,7 @@ int DruidChallenger(struct char_data* ch, int cmd, char* arg, struct char_data* 
 			DruidHeal(ch, level);
 			return(TRUE);
 		}
-		if (!ch->equipment[WIELD]) {
+		if (!ch->equipment[WIELD] && number(0,100) > 95) {
 			if (GetMaxLevel(ch) > 4) {
 				act("$n pronuncia le parole 'gimme a light'", 1, ch, 0, 0, TO_ROOM);
 				cast_elemental_blade(GetMaxLevel(ch), ch, "", SPELL_TYPE_SPELL, ch, 0);


### PR DESCRIPTION
aggiunto un caso che riduce la probabilità dei mob di castare elemental blade.
Nuova procedura di haste:
haste ha bisogno di mille check: se sei in parry, sott'acqua, su un cavallo, stanco o se devi fare pipì. Quindi anziche fare mille casi ho messo alla fine della catena un incremento degli attacchi consentiti dalla tua condizione, con un min di 0 e un max dei tuoi attacchi consentiti. A cavallo tipo un wa ne fa 2 massimo, quindi con haste ne aggiunge tra 0 e 2. Il dado viene lanciato ogni round. E per ogni attacco che guadagni perdi 10 mov