### PR TITLE
Dt and haste

### DIFF
--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -715,7 +715,7 @@ const char* spell_wear_off_soon_msg[] = {
 	"!fear!",
 	"!acid blast!",
 	"Per un attimo fatichi a respirare, stai perdendo la capacita' di respirare sott'acqua.",
-	"Ti snti un po' piu' pesante, stai perdendo la capacita' di volare.",
+	"Ti senti un po' piu' pesante, stai perdendo la capacita' di volare.",
 	"spell1, please report.",   /* 70 */
 	"spell2, please report.",
 	"spell3, please report.",

--- a/src/fight.cpp
+++ b/src/fight.cpp
@@ -4563,20 +4563,37 @@ struct char_data* FindMetaVictim( struct char_data* ch) {
 */
 void NailThisSucker( struct char_data* ch) {
 
-	struct char_data* pers;
+	/*struct char_data* pers;*/
 	long room_num;
 	struct room_data* rp;
-	struct obj_data* obj, *next_o;
+	/*struct obj_data* obj, *next_o;*/
 
 	rp = real_roomp(ch->in_room);
 	room_num=ch->in_room;
-
+    
+        char_from_room(ch);
+        if(IS_PC( ch )) {
+            char_to_room(ch,1);
+            GET_POS(ch) = POSITION_STUNNED;
+            mudlog( LOG_PLAYERS, "%s hit a DeathTrap in room %s[%ld]\r\n",
+               GET_NAME_DESC(ch), real_roomp(room_num)->name,room_num );
+        } else {
+            if(ch->lStartRoom != 0) {
+            char_to_room( ch, ch->lStartRoom );
+            } else {
+                /* transfer rimuove la stanza d'appartenenza al mob, mettiamo un check che
+                   elimini direttamente il mob nel caso. */
+                extract_char(ch);
+            }
+        }
+    
+/*
 	death_cry(ch);
 
 	if( IS_NPC( ch ) && IS_SET( ch->specials.act, ACT_POLYSELF ) ) {
-		/*
-		 *   take char from storage, to room
-		 */
+
+        comment: take char from storage, to room
+ 
 		pers = ch->desc->original;
 		char_from_room(pers);
 		char_to_room(pers, ch->in_room);
@@ -4593,13 +4610,14 @@ void NailThisSucker( struct char_data* ch) {
 	zero_rent(ch);
 	extract_char(ch);
 
-	/* delete EQ dropped by them if room was a DT */
+    comment: delete EQ dropped by them if room was a DT
 	if (IS_SET(rp->room_flags,DEATH)) {
 		for (obj = real_roomp(room_num)->contents; obj; obj = next_o) {
 			next_o = obj->next_content;
 			extract_obj(obj);
-		}  /* end DT for */
+		}
 	}
+    */
 }
 
 

--- a/src/fight.cpp
+++ b/src/fight.cpp
@@ -3194,7 +3194,6 @@ void PCAttacks( char_data* pChar ) {
 	struct obj_data* pTmp = NULL;
 	struct obj_data* pWeapon = NULL; // SALVO la setto NULL mi serve per dopo
 	int perc, dice;
-    float extra_attacks;
 
 	/* Controlla se il tipo e' in parrying, in questo caso
 	   diminuisce gli attacchi di uno per ogni attacco
@@ -3240,37 +3239,11 @@ void PCAttacks( char_data* pChar ) {
 	/* work through all of their attacks, until there is not
 	 * a full attack left */
 
-    /* REQUIEM 2018 random haste */
+    /* REQUIEM 2018 mov consumation by haste */
     
-    if (affected_by_spell(pChar, SPELL_HASTE)) {
-     
-        extra_attacks = number(0.0,fAttacks);
-        
-        /* diamo una mano ai ladri */
-        dice = number(0,2);
-        if(HasClass(pChar, CLASS_THIEF) && dice > 0) {
-            switch(dice) {
-                case 1:
-                    extra_attacks += 0.5;
-                    mudlog(LOG_CHECK,"Adding random 0.5 bonus attack for thieves affected by haste.");
-                    break;
-                case 2:
-                    extra_attacks += 1.0;
-                    mudlog(LOG_CHECK,"Adding random 1 bonus attack for thieves affected by haste.");
-                    break;
-                default:
-                    break;
-            }
-        }
-        
-        if (extra_attacks > 0.0) {
-            GET_MOVE(pChar) -= number(1,3)*((int)(extra_attacks));
+    if (affected_by_spell(pChar, SPELL_HASTE) ) {
+            GET_MOVE(pChar) -= number(1,5)*((int)(fAttacks));
             alter_move(pChar, 0);
-        }
-        
-        fAttacks += extra_attacks;
-        mudlog(LOG_CHECK,"nuovo fAttacks = %f",fAttacks);
-        
     }
 
 

--- a/src/handler.cpp
+++ b/src/handler.cpp
@@ -710,20 +710,11 @@ void affect_modify(struct char_data* ch,byte loc, long mod, long bitv,bool add) 
 		break;
 
 	case APPLY_HASTE:
-        /* REQUIEM 2018 - applico un incremento del num. di attacchi fisso, se haste deriva da eq */
-		
-        if (mod > 0) {
-            mudlog(LOG_PLAYERS,"%s: num attacks altered by equip = %d",GET_NAME(ch),mod);
-            ch->mult_att += float(mod);
-        }
-            
-        if(affected_by_spell(ch, SPELL_HASTE) || mod < 0) {
-            /* ricalcolo il numero di attacchi originali */
-            reset_original_numattacks(ch);
-        }
-            
-        
-        break;
+		if (mod > 0)
+		{ ch->mult_att *= 2.0; }
+		else if (mod < 0)
+		{ ch->mult_att /= 2.0; }
+		break;
 
 	case APPLY_SLOW:
 		if (mod > 0)

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -597,6 +597,7 @@ void spell_teleport(byte level, struct char_data* ch,
 		room = real_roomp(to_room);
 		if (room) {
 			if ((IS_SET(room->room_flags, PRIVATE)) ||
+                    (IS_SET(room->room_flags, DEATH) && IS_NPC(victim)) ||
 					(IS_SET(room->room_flags, TUNNEL)) ||
 					(IS_SET(room->room_flags, NO_SUM)) ||
 					(IS_SET(room->room_flags, NO_MAGIC)) ||
@@ -623,12 +624,13 @@ void spell_teleport(byte level, struct char_data* ch,
 	act("$n torna visibile un po' per volta.", FALSE, ch,0,0,TO_ROOM);
 
 	do_look(ch, "", 15);
-
+    
+    /* Questo non deve accadere
 	if (IS_SET(real_roomp(to_room)->room_flags, DEATH) &&
 			GetMaxLevel(ch) < LOW_IMMORTAL) {
 		NailThisSucker(ch);
 		return;
-	}
+	}*/
 
 	check_falling(ch);
 

--- a/src/magic3.cpp
+++ b/src/magic3.cpp
@@ -303,10 +303,10 @@ void spell_haste(byte level, struct char_data* ch,
 
 	send_to_char("Ti senti veloce....\n\r", victim);
     
-    dice = number(3, 19)
+    dice = number(3, 19);
     
     if(GET_INT(victim) < dice) {
-        send_to_char("La tua mente non riesce a cordinare l'accellerazione degli impulsi del tuo corpo... Perdi conoscenza!\n\r",victim);
+        send_to_char("La tua mente non riesce a coordinare l'accellerazione degli impulsi del tuo corpo... Perdi conoscenza!\n\r",victim);
         GET_POS(victim) = POSITION_STUNNED;
     }
 

--- a/src/magic3.cpp
+++ b/src/magic3.cpp
@@ -270,6 +270,7 @@ void spell_scare(byte level, struct char_data* ch,
 void spell_haste(byte level, struct char_data* ch,
 				 struct char_data* victim, struct obj_data* obj) {
 	struct affected_type af;
+    int dice;
 
 	if (affected_by_spell(victim, SPELL_HASTE)) {
 		act("$N si muove gia piu' velocemente!",FALSE,ch,0,victim,TO_CHAR);
@@ -294,31 +295,20 @@ void spell_haste(byte level, struct char_data* ch,
 
 
 	af.type      = SPELL_HASTE;
-    
-    switch (HowManyClasses(ch)) {
-            
-        case 1:
-            af.duration  = 4;
-            break;
-        case 2:
-            af.duration  = 1;
-            break;
-        case 3:
-            af.duration  = 1;
-            break;
-        default:
-            break;
-            
-    }
-    
-	af.modifier  = 0;
+    af.duration  = level/HowManyClasses(ch);
+	af.modifier  = 1;
 	af.location  = APPLY_HASTE;
 	af.bitvector = 0;
 	affect_to_char(victim, &af);
 
-	send_to_char("Ti senti veloce.... e nulla piu'!\n\r", victim);
-	send_to_char("Perdi conoscenza\n\r",victim);
-	GET_POS(victim) = POSITION_STUNNED;
+	send_to_char("Ti senti veloce....\n\r", victim);
+    
+    dice = number(3, 19)
+    
+    if(GET_INT(victim) < dice) {
+        send_to_char("La tua mente non riesce a cordinare l'accellerazione degli impulsi del tuo corpo... Perdi conoscenza!\n\r",victim);
+        GET_POS(victim) = POSITION_STUNNED;
+    }
 
 	if (!in_group(ch, victim)) {
 		if (!IS_PC(ch))

--- a/src/mindskills1.cpp
+++ b/src/mindskills1.cpp
@@ -115,6 +115,7 @@ void mind_teleport(byte level, struct char_data* ch,
 		room = real_roomp(to_room);
 		if (room) {
 			if ((IS_SET(room->room_flags, PRIVATE)) ||
+                    (IS_SET(room->room_flags, DEATH) && IS_NPC(victim)) ||
 					(IS_SET(room->room_flags, TUNNEL)) ||
 					(IS_SET(room->room_flags, NO_SUM)) ||
 					(IS_SET(room->room_flags, NO_MAGIC)) ||
@@ -140,12 +141,13 @@ void mind_teleport(byte level, struct char_data* ch,
 	act("Una massa di particelle luminose si compone nella figura di $n!", FALSE, ch,0,0,TO_ROOM);
 
 	do_look(ch, "", 15);
-
+    
+    /* questo non deve accadere
 	if (IS_SET(real_roomp(to_room)->room_flags, DEATH) &&
 			GetMaxLevel(ch) < IMMORTALE) {
 		NailThisSucker(ch);
 		return;
-	}
+	}*/
 
 	check_falling(ch);
 

--- a/src/regen.cpp
+++ b/src/regen.cpp
@@ -234,9 +234,7 @@ EVENTFUNC(points_event) {
 		fGain = modf(((double)(move_gain(ch))/(double)(NUMBER_REGEN_EVENTS)), &dum );
 		fGain = fGain*(double)(r_mult) ;
 		gain = (int)( dum );
-            if (affected_by_spell(ch, SPELL_HASTE)) {
-                gain /= 2;
-            }
+
 		rnd =  ( rand()% r_mult) ;
 		/* Here we add a line that on average helps to take
 		   into account fractional gains */

--- a/src/spec_procs.cpp
+++ b/src/spec_procs.cpp
@@ -759,7 +759,7 @@ int ThiefGuildMaster( struct char_data* ch, int cmd, char* arg,
 		}
 		else {
 			number = old_search_block(arg,0,strlen(arg),n_skills,FALSE);
-			send_to_char ("Il Masestro dei Ladri dice ",ch);
+			send_to_char ("Il Maestro dei Ladri dice ",ch);
 
 			if (number == -1) {
 				send_to_char("'Non conosco questa abilita'.'\n\r", ch);


### PR DESCRIPTION
Le dt ora portano i mob alla loro stanza di partenza, i players nel limbo stunnati(room 1). Non si finisce piu' in DT se a teleportarsi e' un mob.

- haste durera'  (livello*tick)/num_classi

- Un consumo di 1d5 per ogni attacco come malus sostituitvo dell'invecchiamento.

- Ci sara' un dado basato su int per lo stun, per i quale senza starvi a spiegare tutto vi dico che chi ha int > 18 non viene stunnato(per avvalorare razze come goldelf e demonic), chi ha 18 o meno affrontera' un dado. Ovviamente maggiore e' int piu' e' facile che la vostra mente[rpg on] riesca a sostenere l'accellerazione degli impulsi del vostro corpo.